### PR TITLE
Fix Typo in AWS deployment documentation

### DIFF
--- a/docs/3.0.0-beta.x/deployment/amazon-aws.md
+++ b/docs/3.0.0-beta.x/deployment/amazon-aws.md
@@ -211,7 +211,7 @@ Strapi currently supports `Node.js v12.x.x`. The following steps will install No
 
 ```bash
 cd ~
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 ...
 sudo apt-get install nodejs
 ...


### PR DESCRIPTION
Following the instructions to install Node.js with npm will result in node version 10 being installed instead of version 12.
